### PR TITLE
Add YAML Validator to Validation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ YAML is a configuration format similar to JSON.
 * [kube-score](https://github.com/zegl/kube-score)
 * [Kubeval](https://www.kubeval.com/)
 * [learnk8s -- blog post](https://learnk8s.io/validating-kubernetes-yaml#kubeval)
+* [YAML Validator](https://yamlvalidator.dev), [(chrome extension)](https://chromewebstore.google.com/detail/yaml-validator/gjgbohnlhijomhfiflapnlnmcpckgigg) - Online YAML validator, formatter and viewer with JSON Schema support (Kubernetes, Docker Compose, GitHub Actions, and more)
 
 ## Tutorial
 <!--- id="dmid://uu086bintt1634232x021xlink" --->


### PR DESCRIPTION
Hi! 👋

Adding [YAML Validator](https://yamlvalidator.dev) to the **Validation** section.

**YAML Validator** is an online YAML validator, formatter and viewer with JSON Schema support for popular formats including Kubernetes, Docker Compose, GitHub Actions, GitLab CI, and more.

Also available as a [Chrome extension](https://chromewebstore.google.com/detail/yaml-validator/gjgbohnlhijomhfiflapnlnmcpckgigg).

Thanks for maintaining this awesome list!